### PR TITLE
Add GET /{slug} endpoint to redirect to original url 

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,33 @@
 import json
+import uvicorn
+from fastapi import FastAPI
+from fastapi.responses import RedirectResponse
+
+app = FastAPI()
+
+# urls acortadas para simular una base de datos
+url_mapping = {
+    'asd': 'https://www.google.com/search?q=asd&ie=UTF-8',
+    'mnp': 'https://www.youtube.com/'
+}
 
 
-def main():
+@app.get('/{slug}')
+def redirect_url(slug: str):
+    """
+    Busca en la base de datos la url
+    asociada al slug(url_acortada)
+    y la redirecciona a su url original
+    """
+
+    # esto simula la busqueda del slug en la base de datos
+    if slug in url_mapping.keys():
+        # redirecciona a la url original
+        return RedirectResponse(url_mapping[slug])
+    return {"error": "url not found"}
+
+
+def read_config():
     with open("config.json") as f:
         config = json.load(f)
         print(config)
@@ -9,4 +35,5 @@ def main():
 
 if __name__ == "__main__":
     print('Versión 0')
-    main()
+    read_config()
+    uvicorn.run("app:app", host="127.0.0.1", port=8000, reload=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn[standard]
+jinja2
+pydantic
+pytest
+httpx
+sqlalchemy


### PR DESCRIPTION
- Crea un endpoint GET /{slug} que recibe como params el slug (identificador del url original) 
- Como primera versión se usa un diccionario para verificar el correcto redireccionamiento
- Añade el comando de `uvicorn.run("app:app", host="127.0.0.1", port=8000, reload=True)` para ejecutar la api