### PR TITLE
add POST /shorter endpoint to generate shorter url 

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,8 +2,27 @@ import json
 import uvicorn
 from fastapi import FastAPI
 from fastapi.responses import RedirectResponse
+from fastapi.templating import Jinja2Templates
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
 
 app = FastAPI()
+
+
+def read_config():
+    with open("config.json") as f:
+        config = json.load(f)
+        return config
+
+
+# Lee el HOST y PORT desde el archivo de configuración
+config = read_config()
+HOST, PORT = config["HOST"], config["PORT"]
+
+# Renderiza los html usando Jinja2
+app.mount("/static", StaticFiles(directory="static"), name="static")
+templates = Jinja2Templates(directory="templates")
+
 
 # urls acortadas para simular una base de datos
 url_mapping = {
@@ -35,5 +54,4 @@ def read_config():
 
 if __name__ == "__main__":
     print('Versión 0')
-    read_config()
-    uvicorn.run("app:app", host="127.0.0.1", port=8000, reload=True)
+    uvicorn.run("app:app", host=HOST, port=PORT, reload=True)

--- a/app.py
+++ b/app.py
@@ -1,7 +1,33 @@
 import json
+import uvicorn
+from fastapi import FastAPI
+from fastapi.responses import RedirectResponse
+
+app = FastAPI()
+
+# urls acortadas para simular una base de datos
+url_mapping = {
+    'asd': 'https://www.google.com/search?q=asd&ie=UTF-8',
+    'mnp': 'https://www.youtube.com/'
+}
 
 
-def main():
+@app.get('/{slug}')
+def redirect_url(slug: str):
+    """
+    Busca en la base de datos la url
+    asociada al slug(url_acortada)
+    y la redirecciona a su url original
+    """
+
+    # esto simula la busqueda del slug en la base de datos
+    if slug in url_mapping.keys():
+        # redirecciona a la url original
+        return RedirectResponse(url_mapping[slug])
+    return {"error": "url not found"}
+
+
+def read_config():
     with open("config.json") as f:
         config = json.load(f)
         print(config)
@@ -9,4 +35,5 @@ def main():
 
 if __name__ == "__main__":
     print('Versión 0')
-    main()
+    read_config()
+    uvicorn.run("app:app", host="127.0.0.1", port=8000, reload=True)

--- a/app.py
+++ b/app.py
@@ -70,6 +70,18 @@ async def generated_url(request: Request, url: str = Form(...)):
     })
 
 
+@app.get('/')
+async def home(request: Request):
+    """
+    Renderiza la página principal donde
+    se encuentra el formulario que enviará
+    el url original
+    """
+    return templates.TemplateResponse('index.html', {
+        "request": request
+    })
+
+
 if __name__ == "__main__":
     print('Versión 0')
     uvicorn.run("app:app", host=HOST, port=PORT, reload=True)

--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 import json
 import uvicorn
-from fastapi import FastAPI
+from fastapi import FastAPI, Request, Form
 from fastapi.responses import RedirectResponse
 from fastapi.templating import Jinja2Templates
 from fastapi.responses import HTMLResponse
@@ -32,7 +32,7 @@ url_mapping = {
 
 
 @app.get('/{slug}')
-def redirect_url(slug: str):
+async def redirect_url(slug: str):
     """
     Busca en la base de datos la url
     asociada al slug(url_acortada)
@@ -46,10 +46,28 @@ def redirect_url(slug: str):
     return {"error": "url not found"}
 
 
-def read_config():
-    with open("config.json") as f:
-        config = json.load(f)
-        print(config)
+@app.post('/shorter', response_class=HTMLResponse)
+async def generated_url(request: Request, url: str = Form(...)):
+    """
+    Toma la url enviada desde el form del index,
+    genera un slug único, almacena los datos
+    en la base de datos y luego devuelve una
+    plantilla html con los datos de la url generada
+    """
+    slug = "asd"  # función que genera un slug a partir del url
+    shortened_url = f"http://{HOST}:{PORT}/{slug}"
+
+    # Aqui se almacena en la base de datos
+
+    # renderiza el template html con la información de la nueva url acortada
+    return templates.TemplateResponse("result.html", {
+        "request": request,
+        "short_url": shortened_url,
+        "original_url": url,
+        "created_at": "6/6/2025",
+        "expires_at": "6/8/2025",
+        "visits": 0
+    })
 
 
 if __name__ == "__main__":

--- a/config.json
+++ b/config.json
@@ -1,3 +1,5 @@
 {
-  "message": "hola mundo"
+  "message": "hola mundo",
+  "HOST": "127.0.0.1",
+  "PORT": 8000
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pydantic
 pytest
 httpx
 sqlalchemy
+python-multipart

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn[standard]
+jinja2
+pydantic
+pytest
+httpx
+sqlalchemy

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Acortador-Link</title>
+  </head>
+  <body>
+    <form
+      action="/shorter
+    "
+      method="post"
+    >
+      <h1>Acortador-Link</h1>
+      <label for="url">Ingresa la URL que deseas acortar:</label>
+      <input
+        type="url"
+        id="url"
+        name="url"
+        required
+        placeholder="https://ejemplo123.com"
+      />
+      <button type="submit">Acortar</button>
+    </form>
+  </body>
+</html>

--- a/templates/result.html
+++ b/templates/result.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Acortador-Link || Link Acortado</title>
+  </head>
+  <body>
+    <h1>Acortador-Link</h1>
+    <p>Tu link acortado es: <a href="{{ short_url }}">{{ short_url }}</a></p>
+    <p>El link original es: {{ original_url }}</p>
+    <p>Visitas: {{ visits }}</p>
+    <p>Fecha de creación: {{ created_at }}</p>
+    <p>Fecha de expiración: {{ expires_at }}</p>
+    <a href="/">Volver al inicio</a>
+  </body>
+</html>


### PR DESCRIPTION
- Modifico app.py para que lea el puerto y host desde el archivo de configuración
- Añado templates básicos hechos con jinja2 para el form(recibe el url original) y la respuesta(url acortado) , estos templates serán desarrollados con más profundidad en sus respectivas ramas
- Añado el endpoint POST /shorter para que genere el url acortado, guarde en la base de datos y luego lo muestre en un html
- Añado el endpoint GET / que será el home que contiene el formulario para enviar el url original